### PR TITLE
the license text and editorconfig

### DIFF
--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -27,7 +27,7 @@ insert_final_newline = false
 # Organize usings
 dotnet_separate_import_directive_groups = true
 dotnet_sort_system_directives_first = true
-file_header_template = unset
+file_header_template = ---------------------------------------------------------------------------- //\n                                                                             //\n  Copyright 2023 Finebits(https://finebits.com/)                             //\n                                                                             //\n  Licensed under the Apache License, Version 2.0 (the "License"),            //\n  you may not use this file except in compliance with the License.           //\n  You may obtain a copy of the License at                                    //\n                                                                             //\n      http://www.apache.org/licenses/LICENSE-2.0                             //\n                                                                             //\n  Unless required by applicable law or agreed to in writing, software        //\n  distributed under the License is distributed on an "AS IS" BASIS,          //\n  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   //\n  See the License for the specific language governing permissions and        //\n  limitations under the License.                                             //\n                                                                             //\n---------------------------------------------------------------------------- //
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent

--- a/source/Authentication.OAuth2.Samlpe/Program.cs
+++ b/source/Authentication.OAuth2.Samlpe/Program.cs
@@ -1,3 +1,21 @@
-﻿#pragma warning disable CA1303 // Do not pass literals as localized parameters
+﻿// ---------------------------------------------------------------------------- //
+//                                                                              //
+//   Copyright 2023 Finebits(https://finebits.com/)                             //
+//                                                                              //
+//   Licensed under the Apache License, Version 2.0 (the "License"),            //
+//   you may not use this file except in compliance with the License.           //
+//   You may obtain a copy of the License at                                    //
+//                                                                              //
+//       http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                              //
+//   Unless required by applicable law or agreed to in writing, software        //
+//   distributed under the License is distributed on an "AS IS" BASIS,          //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   //
+//   See the License for the specific language governing permissions and        //
+//   limitations under the License.                                             //
+//                                                                              //
+// ---------------------------------------------------------------------------- //
+
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
 Console.WriteLine("Hello, World!");
 #pragma warning restore CA1303 // Do not pass literals as localized parameters

--- a/source/Authentication.OAuth2.Test/UnitTest.cs
+++ b/source/Authentication.OAuth2.Test/UnitTest.cs
@@ -1,3 +1,21 @@
+// ---------------------------------------------------------------------------- //
+//                                                                              //
+//   Copyright 2023 Finebits(https://finebits.com/)                             //
+//                                                                              //
+//   Licensed under the Apache License, Version 2.0 (the "License"),            //
+//   you may not use this file except in compliance with the License.           //
+//   You may obtain a copy of the License at                                    //
+//                                                                              //
+//       http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                              //
+//   Unless required by applicable law or agreed to in writing, software        //
+//   distributed under the License is distributed on an "AS IS" BASIS,          //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   //
+//   See the License for the specific language governing permissions and        //
+//   limitations under the License.                                             //
+//                                                                              //
+// ---------------------------------------------------------------------------- //
+
 using System.Diagnostics.CodeAnalysis;
 
 namespace Authentication.OAuth2.Test;

--- a/source/Authentication.OAuth2.Test/Usings.cs
+++ b/source/Authentication.OAuth2.Test/Usings.cs
@@ -1,1 +1,19 @@
+// ---------------------------------------------------------------------------- //
+//                                                                              //
+//   Copyright 2023 Finebits(https://finebits.com/)                             //
+//                                                                              //
+//   Licensed under the Apache License, Version 2.0 (the "License"),            //
+//   you may not use this file except in compliance with the License.           //
+//   You may obtain a copy of the License at                                    //
+//                                                                              //
+//       http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                              //
+//   Unless required by applicable law or agreed to in writing, software        //
+//   distributed under the License is distributed on an "AS IS" BASIS,          //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   //
+//   See the License for the specific language governing permissions and        //
+//   limitations under the License.                                             //
+//                                                                              //
+// ---------------------------------------------------------------------------- //
+
 global using NUnit.Framework;

--- a/source/Authentication.OAuth2/ClassLib.cs
+++ b/source/Authentication.OAuth2/ClassLib.cs
@@ -1,4 +1,22 @@
-﻿namespace Finebits.Authentication.OAuth2
+﻿// ---------------------------------------------------------------------------- //
+//                                                                              //
+//   Copyright 2023 Finebits(https://finebits.com/)                             //
+//                                                                              //
+//   Licensed under the Apache License, Version 2.0 (the "License"),            //
+//   you may not use this file except in compliance with the License.           //
+//   You may obtain a copy of the License at                                    //
+//                                                                              //
+//       http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                              //
+//   Unless required by applicable law or agreed to in writing, software        //
+//   distributed under the License is distributed on an "AS IS" BASIS,          //
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   //
+//   See the License for the specific language governing permissions and        //
+//   limitations under the License.                                             //
+//                                                                              //
+// ---------------------------------------------------------------------------- //
+
+namespace Finebits.Authentication.OAuth2
 {
     public class ClassLib
     {


### PR DESCRIPTION
add the license text to the 'file_header_template' editorconfig parameter.
update .cs files

p.s.
`;` is used for comments in the **.editorconfig** file. [File Format Details](https://editorconfig.org/), but Visual Studio ignores the `Comments should go on their own lines` rule, so the apache-2.0 license line has been changed: 
`Licensed under the Apache License, Version 2.0 (the "License"),`
Original line: `Licensed under the Apache License, Version 2.0 (the "License");`
